### PR TITLE
NEPT-2588: Prevent any process if the purge is disabled.

### DIFF
--- a/nexteuropa_varnish.module
+++ b/nexteuropa_varnish.module
@@ -494,6 +494,9 @@ function _nexteuropa_varnish_purge_paths($paths) {
  *   TRUE if all requests have been sent successfully; otherwise FALSE.
  */
 function _nexteuropa_varnish_varnish_requests_send($path_regexp_rules = array()) {
+  if (_nexteuropa_varnish_prevent_purge()) {
+    return FALSE;
+  }
   try {
     $settings = _nexteuropa_varnish_get_varnish_settings();
 


### PR DESCRIPTION
## NEPT-2588

### Description

Prevent any process if the purge is disabled.

### Change log

- Added: Additional check before sending purge request. This is to prevent subsites code sending purge request using the callback function to go through when purge is disabled.
