### PR TITLE
NEPT-2774: Next Europa varnish generating php error.

### DIFF
--- a/nexteuropa_varnish.module
+++ b/nexteuropa_varnish.module
@@ -703,20 +703,20 @@ function _nexteuropa_varnish_get_node_paths($node) {
     else {
       // Content translation.
       $lang_code = entity_language('node', $node);
-      $all_languages = language_list();
+      $enabled_languages = language_list('enabled')[1];
       $alias = drupal_get_path_alias($entity_uri['path'], $lang_code);
       $original_alias = $alias;
 
       // Language is undefined, the content will show on all languages.
       if (LANGUAGE_NONE == $lang_code) {
-        foreach ($all_languages as $code => $data) {
-          $lang = $all_languages[$code];
+        foreach ($enabled_languages as $code => $data) {
+          $lang = $enabled_languages[$code];
           // Add the prefix or suffix.
           $paths[$code] = _nexteuropa_varnish_build_path($url_locale, $lang, $alias, $entity_uri);
         }
       }
       else {
-        $lang = $all_languages[$lang_code];
+        $lang = $enabled_languages[$lang_code];
         // Add the prefix or suffix.
         $paths[$lang_code] = _nexteuropa_varnish_build_path($url_locale, $lang, $alias, $entity_uri);
       }


### PR DESCRIPTION
## NEPT-2774

### Description

Notice: Undefined index: prefix in _nexteuropa_varnish_build_path() (line 781 of /ec/prod/app/webroot/drupalm_home/reference-sources/multisite/multisite_master_test.2.5/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.module).

The issue is that on nexteuropa varnish :
     We manage all installed languages:
           https://github.com/ec-europa/platform-dev/blob/release-2.5/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.module#L706

    And supposed to add a prefix on each of them:
          https://github.com/ec-europa/platform-dev/blob/release-2.5/profiles/common/modules/custom/nexteuropa_varnish/nexteuropa_varnish.module#L773
           
    But drupal core adds a prefix on enabled languages only :
      includes/locale.inc line 419

